### PR TITLE
Sprint 2: Add localized public routes (cases, posts, contact) and SEO scaffolding

### DIFF
--- a/app/[locale]/cases/[slug]/page.tsx
+++ b/app/[locale]/cases/[slug]/page.tsx
@@ -28,6 +28,9 @@ export async function generateMetadata({ params }: CaseDetailPageProps): Promise
     site,
     locale,
     pathname: `/cases/${slug}`,
+    localizedPathnames: {
+      [locale]: `/cases/${slug}`,
+    },
   });
 }
 

--- a/app/[locale]/cases/[slug]/page.tsx
+++ b/app/[locale]/cases/[slug]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: CaseDetailPageProps): Promise
   const host = (await headers()).get("host");
   const { site, locale } = resolveSiteAndLocale(host, requestedLocale);
 
-  const entry = getPublishedEntry("case", locale, slug);
+  const entry = getPublishedEntry(site.key, "case", locale, slug);
   if (!entry) {
     return {};
   }
@@ -35,8 +35,10 @@ export async function generateMetadata({ params }: CaseDetailPageProps): Promise
 }
 
 export default async function CaseDetailPage({ params }: CaseDetailPageProps) {
-  const { locale, slug } = await params;
-  const entry = getPublishedEntry("case", locale, slug);
+  const { locale: requestedLocale, slug } = await params;
+  const host = (await headers()).get("host");
+  const { site, locale } = resolveSiteAndLocale(host, requestedLocale);
+  const entry = getPublishedEntry(site.key, "case", locale, slug);
 
   if (!entry) {
     notFound();

--- a/app/[locale]/cases/[slug]/page.tsx
+++ b/app/[locale]/cases/[slug]/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+
+import { getPublishedEntry } from "@/lib/content/public-content";
+import { buildLocaleMetadata } from "@/lib/site/seo";
+import { resolveSiteAndLocale } from "@/lib/site/resolve-context";
+
+import styles from "../../public.module.css";
+
+type CaseDetailPageProps = {
+  params: Promise<{ locale: string; slug: string }>;
+};
+
+export async function generateMetadata({ params }: CaseDetailPageProps): Promise<Metadata> {
+  const { locale: requestedLocale, slug } = await params;
+  const host = (await headers()).get("host");
+  const { site, locale } = resolveSiteAndLocale(host, requestedLocale);
+
+  const entry = getPublishedEntry("case", locale, slug);
+  if (!entry) {
+    return {};
+  }
+
+  return buildLocaleMetadata({
+    title: entry.title,
+    description: entry.summary,
+    site,
+    locale,
+    pathname: `/cases/${slug}`,
+  });
+}
+
+export default async function CaseDetailPage({ params }: CaseDetailPageProps) {
+  const { locale, slug } = await params;
+  const entry = getPublishedEntry("case", locale, slug);
+
+  if (!entry) {
+    notFound();
+  }
+
+  return (
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <h1 className={styles.title}>{entry.title}</h1>
+        <p className={styles.meta}>{entry.body}</p>
+      </main>
+    </div>
+  );
+}

--- a/app/[locale]/cases/page.tsx
+++ b/app/[locale]/cases/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { headers } from "next/headers";
+
+import { listPublishedEntries } from "@/lib/content/public-content";
+import { buildLocaleMetadata } from "@/lib/site/seo";
+import { resolveSiteAndLocale } from "@/lib/site/resolve-context";
+
+import styles from "../public.module.css";
+
+type CasesPageProps = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: CasesPageProps): Promise<Metadata> {
+  const { locale: requestedLocale } = await params;
+  const host = (await headers()).get("host");
+  const { site, locale } = resolveSiteAndLocale(host, requestedLocale);
+
+  return buildLocaleMetadata({
+    title: "Cases",
+    description: "Published customer stories.",
+    site,
+    locale,
+    pathname: "/cases",
+  });
+}
+
+export default async function CasesPage({ params }: CasesPageProps) {
+  const { locale } = await params;
+  const entries = listPublishedEntries("case", locale);
+
+  return (
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <h1 className={styles.title}>Cases</h1>
+        <ul className={styles.list}>
+          {entries.map((entry) => (
+            <li key={entry.slug}>
+              <Link href={`/${locale}/cases/${entry.slug}`}>{entry.title}</Link>
+              <p className={styles.meta}>{entry.summary}</p>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </div>
+  );
+}

--- a/app/[locale]/cases/page.tsx
+++ b/app/[locale]/cases/page.tsx
@@ -27,8 +27,10 @@ export async function generateMetadata({ params }: CasesPageProps): Promise<Meta
 }
 
 export default async function CasesPage({ params }: CasesPageProps) {
-  const { locale } = await params;
-  const entries = listPublishedEntries("case", locale);
+  const { locale: requestedLocale } = await params;
+  const host = (await headers()).get("host");
+  const { site, locale } = resolveSiteAndLocale(host, requestedLocale);
+  const entries = listPublishedEntries(site.key, "case", locale);
 
   return (
     <div className={styles.page}>

--- a/app/[locale]/contact/page.tsx
+++ b/app/[locale]/contact/page.tsx
@@ -1,0 +1,45 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+
+import { getPublishedEntry } from "@/lib/content/public-content";
+import { buildLocaleMetadata } from "@/lib/site/seo";
+import { resolveSiteAndLocale } from "@/lib/site/resolve-context";
+
+import styles from "../public.module.css";
+
+type ContactPageProps = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: ContactPageProps): Promise<Metadata> {
+  const { locale: requestedLocale } = await params;
+  const host = (await headers()).get("host");
+  const { site, locale } = resolveSiteAndLocale(host, requestedLocale);
+
+  return buildLocaleMetadata({
+    title: "Contact",
+    description: "Get in touch with Forte Digital.",
+    site,
+    locale,
+    pathname: "/contact",
+  });
+}
+
+export default async function ContactPage({ params }: ContactPageProps) {
+  const { locale } = await params;
+  const entry = getPublishedEntry("page", locale, "contact");
+
+  if (!entry) {
+    notFound();
+  }
+
+  return (
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <h1 className={styles.title}>{entry.title}</h1>
+        <p className={styles.meta}>{entry.body}</p>
+      </main>
+    </div>
+  );
+}

--- a/app/[locale]/contact/page.tsx
+++ b/app/[locale]/contact/page.tsx
@@ -27,8 +27,10 @@ export async function generateMetadata({ params }: ContactPageProps): Promise<Me
 }
 
 export default async function ContactPage({ params }: ContactPageProps) {
-  const { locale } = await params;
-  const entry = getPublishedEntry("page", locale, "contact");
+  const { locale: requestedLocale } = await params;
+  const host = (await headers()).get("host");
+  const { site, locale } = resolveSiteAndLocale(host, requestedLocale);
+  const entry = getPublishedEntry(site.key, "page", locale, "contact");
 
   if (!entry) {
     notFound();

--- a/app/[locale]/layout.tsx
+++ b/app/[locale]/layout.tsx
@@ -1,0 +1,22 @@
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+
+import { resolveSiteAndLocale } from "@/lib/site/resolve-context";
+
+type LocaleLayoutProps = Readonly<{
+  children: React.ReactNode;
+  params: Promise<{ locale: string }>;
+}>;
+
+export default async function LocaleLayout({ children, params }: LocaleLayoutProps) {
+  const { locale: requestedLocale } = await params;
+  const host = (await headers()).get("host");
+
+  try {
+    resolveSiteAndLocale(host, requestedLocale);
+  } catch {
+    notFound();
+  }
+
+  return <>{children}</>;
+}

--- a/app/[locale]/page.tsx
+++ b/app/[locale]/page.tsx
@@ -1,21 +1,48 @@
+import type { Metadata } from "next";
+import Link from "next/link";
 import { headers } from "next/headers";
 import { notFound } from "next/navigation";
 
-import styles from "../page.module.css";
+import styles from "./public.module.css";
+import { buildLocaleMetadata } from "@/lib/site/seo";
 import { resolveSiteAndLocale } from "@/lib/site/resolve-context";
 
 type LocalePageProps = {
   params: Promise<{ locale: string }>;
 };
 
+async function resolveContext(requestedLocale: string) {
+  const host = (await headers()).get("host");
+
+  return resolveSiteAndLocale(host, requestedLocale);
+}
+
+export async function generateMetadata({ params }: LocalePageProps): Promise<Metadata> {
+  const { locale: requestedLocale } = await params;
+
+  try {
+    const { site, locale } = await resolveContext(requestedLocale);
+
+    return buildLocaleMetadata({
+      title: "Forte Digital MVP",
+      description: "Public web baseline for localized pages.",
+      site,
+      locale,
+      pathname: "",
+    });
+  } catch {
+    return {};
+  }
+}
+
 export default async function LocalePage({ params }: LocalePageProps) {
   const { locale: requestedLocale } = await params;
-  const host = (await headers()).get("host");
+
   let site: ReturnType<typeof resolveSiteAndLocale>["site"];
   let locale: ReturnType<typeof resolveSiteAndLocale>["locale"];
 
   try {
-    ({ site, locale } = resolveSiteAndLocale(host, requestedLocale));
+    ({ site, locale } = await resolveContext(requestedLocale));
   } catch {
     notFound();
   }
@@ -23,19 +50,15 @@ export default async function LocalePage({ params }: LocalePageProps) {
   return (
     <div className={styles.page}>
       <main className={styles.main}>
-        <p className={styles.badge}>Sprint 1 · Fundament</p>
-        <h1 className={styles.title}>Forte Digital MVP er initialisert</h1>
-        <ul className={styles.list}>
-          <li>
-            <strong>Site/market:</strong> {site.key}
-          </li>
-          <li>
-            <strong>Domain:</strong> {site.primaryDomain}
-          </li>
-          <li>
-            <strong>Locale:</strong> {locale}
-          </li>
-        </ul>
+        <h1 className={styles.title}>Forte Digital MVP</h1>
+        <p className={styles.meta}>
+          Site: {site.key} · Domain: {site.primaryDomain} · Locale: {locale}
+        </p>
+        <nav className={styles.nav}>
+          <Link href={`/${locale}/cases`}>Cases</Link>
+          <Link href={`/${locale}/posts`}>Posts</Link>
+          <Link href={`/${locale}/contact`}>Contact</Link>
+        </nav>
       </main>
     </div>
   );

--- a/app/[locale]/posts/[slug]/page.tsx
+++ b/app/[locale]/posts/[slug]/page.tsx
@@ -28,6 +28,9 @@ export async function generateMetadata({ params }: PostDetailPageProps): Promise
     site,
     locale,
     pathname: `/posts/${slug}`,
+    localizedPathnames: {
+      [locale]: `/posts/${slug}`,
+    },
   });
 }
 

--- a/app/[locale]/posts/[slug]/page.tsx
+++ b/app/[locale]/posts/[slug]/page.tsx
@@ -17,7 +17,7 @@ export async function generateMetadata({ params }: PostDetailPageProps): Promise
   const host = (await headers()).get("host");
   const { site, locale } = resolveSiteAndLocale(host, requestedLocale);
 
-  const entry = getPublishedEntry("post", locale, slug);
+  const entry = getPublishedEntry(site.key, "post", locale, slug);
   if (!entry) {
     return {};
   }
@@ -35,8 +35,10 @@ export async function generateMetadata({ params }: PostDetailPageProps): Promise
 }
 
 export default async function PostDetailPage({ params }: PostDetailPageProps) {
-  const { locale, slug } = await params;
-  const entry = getPublishedEntry("post", locale, slug);
+  const { locale: requestedLocale, slug } = await params;
+  const host = (await headers()).get("host");
+  const { site, locale } = resolveSiteAndLocale(host, requestedLocale);
+  const entry = getPublishedEntry(site.key, "post", locale, slug);
 
   if (!entry) {
     notFound();

--- a/app/[locale]/posts/[slug]/page.tsx
+++ b/app/[locale]/posts/[slug]/page.tsx
@@ -1,0 +1,50 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+import { notFound } from "next/navigation";
+
+import { getPublishedEntry } from "@/lib/content/public-content";
+import { buildLocaleMetadata } from "@/lib/site/seo";
+import { resolveSiteAndLocale } from "@/lib/site/resolve-context";
+
+import styles from "../../public.module.css";
+
+type PostDetailPageProps = {
+  params: Promise<{ locale: string; slug: string }>;
+};
+
+export async function generateMetadata({ params }: PostDetailPageProps): Promise<Metadata> {
+  const { locale: requestedLocale, slug } = await params;
+  const host = (await headers()).get("host");
+  const { site, locale } = resolveSiteAndLocale(host, requestedLocale);
+
+  const entry = getPublishedEntry("post", locale, slug);
+  if (!entry) {
+    return {};
+  }
+
+  return buildLocaleMetadata({
+    title: entry.title,
+    description: entry.summary,
+    site,
+    locale,
+    pathname: `/posts/${slug}`,
+  });
+}
+
+export default async function PostDetailPage({ params }: PostDetailPageProps) {
+  const { locale, slug } = await params;
+  const entry = getPublishedEntry("post", locale, slug);
+
+  if (!entry) {
+    notFound();
+  }
+
+  return (
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <h1 className={styles.title}>{entry.title}</h1>
+        <p className={styles.meta}>{entry.body}</p>
+      </main>
+    </div>
+  );
+}

--- a/app/[locale]/posts/page.tsx
+++ b/app/[locale]/posts/page.tsx
@@ -27,8 +27,10 @@ export async function generateMetadata({ params }: PostsPageProps): Promise<Meta
 }
 
 export default async function PostsPage({ params }: PostsPageProps) {
-  const { locale } = await params;
-  const entries = listPublishedEntries("post", locale);
+  const { locale: requestedLocale } = await params;
+  const host = (await headers()).get("host");
+  const { site, locale } = resolveSiteAndLocale(host, requestedLocale);
+  const entries = listPublishedEntries(site.key, "post", locale);
 
   return (
     <div className={styles.page}>

--- a/app/[locale]/posts/page.tsx
+++ b/app/[locale]/posts/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { headers } from "next/headers";
+
+import { listPublishedEntries } from "@/lib/content/public-content";
+import { buildLocaleMetadata } from "@/lib/site/seo";
+import { resolveSiteAndLocale } from "@/lib/site/resolve-context";
+
+import styles from "../public.module.css";
+
+type PostsPageProps = {
+  params: Promise<{ locale: string }>;
+};
+
+export async function generateMetadata({ params }: PostsPageProps): Promise<Metadata> {
+  const { locale: requestedLocale } = await params;
+  const host = (await headers()).get("host");
+  const { site, locale } = resolveSiteAndLocale(host, requestedLocale);
+
+  return buildLocaleMetadata({
+    title: "Posts",
+    description: "Published updates and news.",
+    site,
+    locale,
+    pathname: "/posts",
+  });
+}
+
+export default async function PostsPage({ params }: PostsPageProps) {
+  const { locale } = await params;
+  const entries = listPublishedEntries("post", locale);
+
+  return (
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <h1 className={styles.title}>Posts</h1>
+        <ul className={styles.list}>
+          {entries.map((entry) => (
+            <li key={entry.slug}>
+              <Link href={`/${locale}/posts/${entry.slug}`}>{entry.title}</Link>
+              <p className={styles.meta}>{entry.summary}</p>
+            </li>
+          ))}
+        </ul>
+      </main>
+    </div>
+  );
+}

--- a/app/[locale]/public.module.css
+++ b/app/[locale]/public.module.css
@@ -1,0 +1,42 @@
+.page {
+  min-height: 100vh;
+  background: #f7f7f9;
+  padding: 2rem;
+}
+
+.main {
+  width: min(760px, 100%);
+  margin: 0 auto;
+  border: 1px solid #e8e8eb;
+  border-radius: 14px;
+  background: #ffffff;
+  padding: 2rem;
+  display: grid;
+  gap: 1rem;
+}
+
+.title {
+  color: #111;
+}
+
+.list {
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.meta {
+  color: #4b5563;
+  font-size: 0.95rem;
+}
+
+.nav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.nav a {
+  color: #2d3f95;
+  text-decoration: underline;
+}

--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,16 @@
+import Link from "next/link";
+
+import styles from "./page.module.css";
+
+export default function NotFoundPage() {
+  return (
+    <div className={styles.page}>
+      <main className={styles.main}>
+        <p className={styles.badge}>404</p>
+        <h1 className={styles.title}>Siden finnes ikke</h1>
+        <p className={styles.list}>Kontroller URL-en eller gå tilbake til forsiden.</p>
+        <Link href="/">Gå til start</Link>
+      </main>
+    </div>
+  );
+}

--- a/lib/content/public-content.ts
+++ b/lib/content/public-content.ts
@@ -1,0 +1,83 @@
+export type ContentType = "page" | "case" | "post";
+export type ContentStatus = "draft" | "review" | "published" | "archived";
+
+export type PublicContentEntry = {
+  type: ContentType;
+  locale: string;
+  slug: string;
+  title: string;
+  summary: string;
+  body: string;
+  status: ContentStatus;
+};
+
+const entries: PublicContentEntry[] = [
+  {
+    type: "case",
+    locale: "en",
+    slug: "migrated-marketing-platform",
+    title: "Migrated a global marketing platform",
+    summary: "How we rebuilt content publishing across markets.",
+    body: "This case highlights architecture, migration strategy, and measurable outcomes.",
+    status: "published",
+  },
+  {
+    type: "case",
+    locale: "no",
+    slug: "migrert-markedsplattform",
+    title: "Migrerte en global markedsplattform",
+    summary: "Hvordan vi bygget ny publiseringsflyt på tvers av markeder.",
+    body: "Denne casen beskriver arkitekturvalg, migrering og målbare resultater.",
+    status: "published",
+  },
+  {
+    type: "post",
+    locale: "en",
+    slug: "launching-the-new-mvp",
+    title: "Launching the new MVP",
+    summary: "What is included in Sprint 2 and why.",
+    body: "In this update we introduce localized routes for cases, posts, and contact pages.",
+    status: "published",
+  },
+  {
+    type: "post",
+    locale: "no",
+    slug: "lansering-av-ny-mvp",
+    title: "Lansering av ny MVP",
+    summary: "Dette leveres i Sprint 2 og hvorfor.",
+    body: "I denne oppdateringen introduserer vi lokale ruter for case, innlegg og kontakt.",
+    status: "published",
+  },
+  {
+    type: "page",
+    locale: "en",
+    slug: "contact",
+    title: "Contact",
+    summary: "Get in touch with Forte Digital.",
+    body: "Send us a message and we will respond shortly.",
+    status: "published",
+  },
+  {
+    type: "page",
+    locale: "no",
+    slug: "contact",
+    title: "Kontakt",
+    summary: "Ta kontakt med Forte Digital.",
+    body: "Send oss en melding, så svarer vi så raskt som mulig.",
+    status: "published",
+  },
+];
+
+export function listPublishedEntries(type: ContentType, locale: string): PublicContentEntry[] {
+  return entries.filter((entry) => entry.type === type && entry.locale === locale && entry.status === "published");
+}
+
+export function getPublishedEntry(type: ContentType, locale: string, slug: string): PublicContentEntry | undefined {
+  return entries.find(
+    (entry) =>
+      entry.type === type &&
+      entry.locale === locale &&
+      entry.slug === slug &&
+      entry.status === "published",
+  );
+}

--- a/lib/content/public-content.ts
+++ b/lib/content/public-content.ts
@@ -2,6 +2,7 @@ export type ContentType = "page" | "case" | "post";
 export type ContentStatus = "draft" | "review" | "published" | "archived";
 
 export type PublicContentEntry = {
+  site: string;
   type: ContentType;
   locale: string;
   slug: string;
@@ -13,6 +14,7 @@ export type PublicContentEntry = {
 
 const entries: PublicContentEntry[] = [
   {
+    site: "global",
     type: "case",
     locale: "en",
     slug: "migrated-marketing-platform",
@@ -22,6 +24,7 @@ const entries: PublicContentEntry[] = [
     status: "published",
   },
   {
+    site: "global",
     type: "case",
     locale: "no",
     slug: "migrert-markedsplattform",
@@ -31,6 +34,7 @@ const entries: PublicContentEntry[] = [
     status: "published",
   },
   {
+    site: "global",
     type: "post",
     locale: "en",
     slug: "launching-the-new-mvp",
@@ -40,6 +44,7 @@ const entries: PublicContentEntry[] = [
     status: "published",
   },
   {
+    site: "global",
     type: "post",
     locale: "no",
     slug: "lansering-av-ny-mvp",
@@ -49,6 +54,7 @@ const entries: PublicContentEntry[] = [
     status: "published",
   },
   {
+    site: "global",
     type: "page",
     locale: "en",
     slug: "contact",
@@ -58,6 +64,7 @@ const entries: PublicContentEntry[] = [
     status: "published",
   },
   {
+    site: "global",
     type: "page",
     locale: "no",
     slug: "contact",
@@ -68,13 +75,25 @@ const entries: PublicContentEntry[] = [
   },
 ];
 
-export function listPublishedEntries(type: ContentType, locale: string): PublicContentEntry[] {
-  return entries.filter((entry) => entry.type === type && entry.locale === locale && entry.status === "published");
+export function listPublishedEntries(site: string, type: ContentType, locale: string): PublicContentEntry[] {
+  return entries.filter(
+    (entry) =>
+      entry.site === site &&
+      entry.type === type &&
+      entry.locale === locale &&
+      entry.status === "published",
+  );
 }
 
-export function getPublishedEntry(type: ContentType, locale: string, slug: string): PublicContentEntry | undefined {
+export function getPublishedEntry(
+  site: string,
+  type: ContentType,
+  locale: string,
+  slug: string,
+): PublicContentEntry | undefined {
   return entries.find(
     (entry) =>
+      entry.site === site &&
       entry.type === type &&
       entry.locale === locale &&
       entry.slug === slug &&

--- a/lib/site/seo.ts
+++ b/lib/site/seo.ts
@@ -12,24 +12,34 @@ export function buildLocaleMetadata({
   site,
   locale,
   pathname,
+  localizedPathnames,
 }: {
   title: string;
   description: string;
   site: SiteConfig;
   locale: string;
   pathname: string;
+  localizedPathnames?: Partial<Record<string, string>>;
 }): Metadata {
   const alternates: Record<string, string> = {};
 
   for (const supportedLocale of site.locales) {
-    alternates[supportedLocale] = createAbsolutePath(site, `/${supportedLocale}${pathname}`);
+    const localePath = localizedPathnames ? localizedPathnames[supportedLocale] : pathname;
+
+    if (!localePath) {
+      continue;
+    }
+
+    alternates[supportedLocale] = createAbsolutePath(site, `/${supportedLocale}${localePath}`);
   }
+
+  const canonicalPath = localizedPathnames?.[locale] ?? pathname;
 
   return {
     title,
     description,
     alternates: {
-      canonical: createAbsolutePath(site, `/${locale}${pathname}`),
+      canonical: createAbsolutePath(site, `/${locale}${canonicalPath}`),
       languages: alternates,
     },
   };

--- a/lib/site/seo.ts
+++ b/lib/site/seo.ts
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+
+import type { SiteConfig } from "@/site.config";
+
+function createAbsolutePath(site: SiteConfig, pathname: string) {
+  return `https://${site.primaryDomain}${pathname}`;
+}
+
+export function buildLocaleMetadata({
+  title,
+  description,
+  site,
+  locale,
+  pathname,
+}: {
+  title: string;
+  description: string;
+  site: SiteConfig;
+  locale: string;
+  pathname: string;
+}): Metadata {
+  const alternates: Record<string, string> = {};
+
+  for (const supportedLocale of site.locales) {
+    alternates[supportedLocale] = createAbsolutePath(site, `/${supportedLocale}${pathname}`);
+  }
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: createAbsolutePath(site, `/${locale}${pathname}`),
+      languages: alternates,
+    },
+  };
+}


### PR DESCRIPTION
### Motivation

- Advance the MVP to Sprint 2 by scaffolding the public web surface for localized content (cases, posts, contact). 
- Provide a minimal server-side content source to render pages immediately while Supabase integration is implemented in a later step. 
- Ensure SEO and locale correctness per site by centralizing metadata generation and adding locale resolution/guarding.

### Description

- Added localized public routes and detail pages under `app/[locale]` for `cases`, `posts`, and `contact`, and updated the localized home at `app/[locale]/page.tsx` to link to them. 
- Introduced a temporary server-side content provider in `lib/content/public-content.ts` with `listPublishedEntries` and `getPublishedEntry` used by the new pages. 
- Added `lib/site/seo.ts` and integrated `generateMetadata` in pages to build canonical and `hreflang` alternates using `buildLocaleMetadata`. 
- Added a locale route guard in `app/[locale]/layout.tsx`, a global `app/not-found.tsx` page, and shared styling in `app/[locale]/public.module.css` for consistent layout.

### Testing

- Ran `pnpm lint` and it completed successfully. 
- Ran `pnpm typecheck` (`tsc --noEmit`) and it completed successfully. 
- Ran `pnpm build` (`next build`) and Next.js built and prerendered the new routes without errors. 
- Started the dev server and executed an automated Playwright script that loaded `/en/cases` and produced a screenshot, confirming the route renders successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699ef6d7cde48324b3ccf4460762226b)