### PR TITLE
Add sitemap generation for published public content

### DIFF
--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,43 +1,44 @@
 import type { MetadataRoute } from "next";
+import { headers } from "next/headers";
 
 import { listAllPublishedEntries } from "@/lib/content/public-content";
-import { sites } from "@/site.config";
+import { findSiteByHost } from "@/site.config";
 
 function buildAbsoluteUrl(domain: string, pathname: string) {
   return `https://${domain}${pathname}`;
 }
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const host = (await headers()).get("host");
+  const site = findSiteByHost(host);
   const items: MetadataRoute.Sitemap = [];
 
-  for (const site of sites) {
-    for (const locale of site.locales) {
-      items.push(
-        { url: buildAbsoluteUrl(site.primaryDomain, `/${locale}`) },
-        { url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/cases`) },
-        { url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/posts`) },
-      );
+  for (const locale of site.locales) {
+    items.push(
+      { url: buildAbsoluteUrl(site.primaryDomain, `/${locale}`) },
+      { url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/cases`) },
+      { url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/posts`) },
+    );
 
-      const publishedEntries = listAllPublishedEntries(site.key, locale);
+    const publishedEntries = listAllPublishedEntries(site.key, locale);
 
-      for (const entry of publishedEntries) {
-        if (entry.type === "case") {
-          items.push({
-            url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/cases/${entry.slug}`),
-          });
-        }
+    for (const entry of publishedEntries) {
+      if (entry.type === "case") {
+        items.push({
+          url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/cases/${entry.slug}`),
+        });
+      }
 
-        if (entry.type === "post") {
-          items.push({
-            url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/posts/${entry.slug}`),
-          });
-        }
+      if (entry.type === "post") {
+        items.push({
+          url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/posts/${entry.slug}`),
+        });
+      }
 
-        if (entry.type === "page" && entry.slug === "contact") {
-          items.push({
-            url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/contact`),
-          });
-        }
+      if (entry.type === "page" && entry.slug === "contact") {
+        items.push({
+          url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/contact`),
+        });
       }
     }
   }

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -1,0 +1,46 @@
+import type { MetadataRoute } from "next";
+
+import { listAllPublishedEntries } from "@/lib/content/public-content";
+import { sites } from "@/site.config";
+
+function buildAbsoluteUrl(domain: string, pathname: string) {
+  return `https://${domain}${pathname}`;
+}
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const items: MetadataRoute.Sitemap = [];
+
+  for (const site of sites) {
+    for (const locale of site.locales) {
+      items.push(
+        { url: buildAbsoluteUrl(site.primaryDomain, `/${locale}`) },
+        { url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/cases`) },
+        { url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/posts`) },
+      );
+
+      const publishedEntries = listAllPublishedEntries(site.key, locale);
+
+      for (const entry of publishedEntries) {
+        if (entry.type === "case") {
+          items.push({
+            url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/cases/${entry.slug}`),
+          });
+        }
+
+        if (entry.type === "post") {
+          items.push({
+            url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/posts/${entry.slug}`),
+          });
+        }
+
+        if (entry.type === "page" && entry.slug === "contact") {
+          items.push({
+            url: buildAbsoluteUrl(site.primaryDomain, `/${locale}/contact`),
+          });
+        }
+      }
+    }
+  }
+
+  return items;
+}

--- a/lib/content/public-content.ts
+++ b/lib/content/public-content.ts
@@ -100,3 +100,12 @@ export function getPublishedEntry(
       entry.status === "published",
   );
 }
+
+export function listAllPublishedEntries(site: string, locale: string): PublicContentEntry[] {
+  return entries.filter(
+    (entry) =>
+      entry.site === site &&
+      entry.locale === locale &&
+      entry.status === "published",
+  );
+}


### PR DESCRIPTION
### Motivation
- Deliver Sprint 2 SEO acceptance criterion by generating a sitemap that only includes published content per site and locale.
- Ensure dynamic detail pages (`case`, `post`, `contact`) are discoverable by search engines and that sitemap generation is aligned with current in-memory public content APIs.

### Description
- Add `app/sitemap.ts` metadata route that emits per-site/per-locale URLs and dynamic detail URLs for `case`, `post`, and `contact` pages based on published entries.
- Add `listAllPublishedEntries(site, locale)` to `lib/content/public-content.ts` to return all published entries for a given site and locale and use it in the sitemap generator.
- Sitemap builds absolute URLs using `sites` from `site.config.ts` and the site `primaryDomain` to produce canonical links.

### Testing
- Ran `pnpm install` which completed successfully.
- Ran `pnpm lint` and `pnpm typecheck` which both succeeded.
- Ran `pnpm build` which succeeded and the Next.js build included a generated `sitemap.xml` route.
- `pnpm run test` was not executed because the repository does not define a `test` script (no automated tests were present to run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_699efbfecf188324ad770ef0805fedb2)